### PR TITLE
More fixes for Windows (using MinGW-w64)

### DIFF
--- a/include/OpenIPMI/internal/ipmi_malloc.h
+++ b/include/OpenIPMI/internal/ipmi_malloc.h
@@ -85,7 +85,7 @@ extern int i__ipmi_debug_malloc;
 
 /* Used by the malloc code to generate logs.  If not set, logs will go
    nowhere. */
-IPMI_UTILS_DLL_EXTERN
+IPMI_UTILS_DLL_PUBLIC
 extern void (*ipmi_malloc_log)(enum ipmi_log_type_e log_type,
 			       const char *format, ...)
 #if __GNUC__ > 2

--- a/lanserv/lanserv.c
+++ b/lanserv/lanserv.c
@@ -233,6 +233,9 @@ smi_send_dev(channel_t *chan, msg_t *msg)
 static int
 gen_rand(lanserv_data_t *lan, void *data, int len)
 {
+#ifdef _WIN32
+    #error gen_rand() to be defined for Windows
+#else
     int fd = open("/dev/urandom", O_RDONLY);
     int rv;
 
@@ -253,6 +256,7 @@ gen_rand(lanserv_data_t *lan, void *data, int len)
  out:
     close(fd);
     return rv;
+#endif
 }
 
 static void

--- a/lanserv/sol.c
+++ b/lanserv/sol.c
@@ -638,7 +638,12 @@ sol_tcp_initialize(ipmi_sol_t *sol)
 	goto out;
     }
 
+#ifdef __WIN32__
+    unsigned long flags = 1;
+    rv = ioctlsocket(sd->fd, FIONBIO, &flags);
+#else
     rv = fcntl(sd->fd, F_SETFL, O_NONBLOCK);
+#endif
     if (rv == -1) {
 	close(sd->fd);
 	sd->fd = -1;

--- a/lanserv/sol.c
+++ b/lanserv/sol.c
@@ -575,7 +575,11 @@ sol_tcp_shutdown(ipmi_sol_t *sol)
     soldata_t *sd = sol->soldata;
 
     if (sd->fd >= 0)
+#ifdef _WIN32
+	closesocket(sd->fd);
+#else
 	close(sd->fd);
+#endif
     sd->fd = -1;
 }
 
@@ -616,7 +620,11 @@ sol_tcp_initialize(ipmi_sol_t *sol)
 
     rv = connect(sd->fd, addr->ai_addr, addr->ai_addrlen);
     if (rv == -1) {
+#ifdef _WIN32
+	closesocket(sd->fd);
+#else
 	close(sd->fd);
+#endif
 	sd->fd = -1;
 	if (sd->sys->debug & DEBUG_SOL)
 	    sd->logchan->log(sd->logchan, OS_ERROR, NULL,
@@ -629,7 +637,11 @@ sol_tcp_initialize(ipmi_sol_t *sol)
     rv = setsockopt(sd->fd, IPPROTO_TCP, TCP_NODELAY,
 		    (char *) &options, sizeof(options));
     if (rv == -1) {
+#ifdef _WIN32
+	closesocket(sd->fd);
+#else
 	close(sd->fd);
+#endif
 	sd->fd = -1;
 	sd->logchan->log(sd->logchan, OS_ERROR, NULL,
 			 "Error setting nodelay on tcp sol port socket"
@@ -645,7 +657,11 @@ sol_tcp_initialize(ipmi_sol_t *sol)
     rv = fcntl(sd->fd, F_SETFL, O_NONBLOCK);
 #endif
     if (rv == -1) {
+#ifdef __WIN32__
+	closesocket(sd->fd);
+#else
 	close(sd->fd);
+#endif
 	sd->fd = -1;
 	sd->logchan->log(sd->logchan, OS_ERROR, NULL,
 			 "Error setting nonblock on tcp sol port socket"

--- a/lib/ipmi_lan.c
+++ b/lib/ipmi_lan.c
@@ -1313,7 +1313,11 @@ find_free_lan_fd(int family, lan_data_t *lan, int *slot)
 	rv = fcntl(item->fd, F_SETFL, O_NONBLOCK);
 #endif
 	if (rv) {
+#ifdef _WIN32
+	    closesocket(item->fd);
+#else
 	    close(item->fd);
+#endif
 	    item->next = *free_list;
 	    *free_list = item;
 	    item = NULL;
@@ -1327,7 +1331,11 @@ find_free_lan_fd(int family, lan_data_t *lan, int *slot)
 					    NULL,
 					    &(item->fd_wait_id));
 	if (rv) {
+#ifdef _WIN32
+	    closesocket(item->fd);
+#else
 	    close(item->fd);
+#endif
 	    item->next = *free_list;
 	    *free_list = item;
 	    item = NULL;
@@ -1354,7 +1362,11 @@ release_lan_fd(lan_fd_t *item, int slot)
     item->cons_in_use--;
     if (item->cons_in_use == 0) {
 	lan_os_hnd->remove_fd_to_wait_for(lan_os_hnd, item->fd_wait_id);
+#ifdef _WIN32
+	closesocket(item->fd);
+#else
 	close(item->fd);
+#endif
 	item->next->prev = item->prev;
 	item->prev->next = item->next;
 	item->next = *(item->free_list);
@@ -7108,7 +7120,11 @@ i_ipmi_lan_shutdown(void)
 	    e->next->prev = e->prev;
 	    e->prev->next = e->next;
 	    lan_os_hnd->remove_fd_to_wait_for(lan_os_hnd, e->fd_wait_id);
+#ifdef _WIN32
+	    closesocket(e->fd);
+#else
 	    close(e->fd);
+#endif
 	    ipmi_destroy_lock(e->con_lock);
 	    ipmi_mem_free(e);
 	}
@@ -7131,7 +7147,11 @@ i_ipmi_lan_shutdown(void)
 	    e->next->prev = e->prev;
 	    e->prev->next = e->next;
 	    lan_os_hnd->remove_fd_to_wait_for(lan_os_hnd, e->fd_wait_id);
+#ifdef _WIN32
+	    closesocket(e->fd);
+#else
 	    close(e->fd);
+#endif
 	    ipmi_destroy_lock(e->con_lock);
 	    ipmi_mem_free(e);
 	}

--- a/lib/oem_atca_conn.c
+++ b/lib/oem_atca_conn.c
@@ -271,7 +271,11 @@ static int register_atca_conn(atca_conn_info_t *info)
 #endif
 	if (rv) {
 	    rv = errno;
+#ifdef _WIN32
+	    closesocket(fd_sock);
+#else
 	    close(fd_sock);
+#endif
 	    fd_sock = -1;
 	    goto out_unlock;
 	}
@@ -283,7 +287,11 @@ static int register_atca_conn(atca_conn_info_t *info)
 					NULL,
 					&fd_wait);
 	if (rv) {
+#ifdef _WIN32
+	    closesocket(fd_sock);
+#else
 	    close(fd_sock);
+#endif
 	    fd_sock = -1;
 	    goto out_unlock;
 	}
@@ -1035,7 +1043,11 @@ ipmi_oem_atca_conn_shutdown(void)
     if (fd_sock != -1) {
 	os_handler_t *os_hnd = ipmi_get_global_os_handler();
 	os_hnd->remove_fd_to_wait_for(os_hnd, fd_wait);
+#ifdef _WIN32
+	closesocket(fd_sock);
+#else
 	close(fd_sock);
+#endif
 	fd_sock = -1;
     }
 

--- a/sample/ipmi_serial_bmc_emu.c
+++ b/sample/ipmi_serial_bmc_emu.c
@@ -1142,7 +1142,11 @@ next_tok(char **str)
 static void
 exit_handler(char *line, struct msg_info *mi)
 {
+#ifdef _WIN32
+    closesocket(mi->sock);
+#else
     close(mi->sock);
+#endif
     exit(0);
 }
 

--- a/sample/rmcp_ping.c
+++ b/sample/rmcp_ping.c
@@ -230,12 +230,22 @@ main(int argc, char *argv[])
     }
 
     /* We want it to be non-blocking. */
+#ifdef __WIN32__
+    unsigned long flags = 1;
+    rv = ioctlsocket(sock, FIONBIO, &flags);
+    if (rv) {
+	closesocket(sock);
+	perror("ioctlsocket(sock, FIONBIO, 1)");
+	exit(1);
+    }
+#else
     rv = fcntl(sock, F_SETFL, O_NONBLOCK);
     if (rv) {
 	close(sock);
 	perror("fcntl(sock, F_SETFL, O_NONBLOCK)");
 	exit(1);
     }
+#endif
 
     val = 1;
     rv = setsockopt(sock, SOL_SOCKET, SO_BROADCAST, &val, sizeof(val));

--- a/tcl/tcl_os_hnd.c
+++ b/tcl/tcl_os_hnd.c
@@ -215,6 +215,9 @@ free_timer(os_handler_t *handler, os_hnd_timer_id_t *id)
 static int
 get_random(os_handler_t *handler, void *data, unsigned int len)
 {
+#ifdef _WIN32
+    #error get_random() to be defined for Windows
+#else
     int fd = open("/dev/urandom", O_RDONLY);
     int rv = 0;
 
@@ -235,6 +238,7 @@ get_random(os_handler_t *handler, void *data, unsigned int len)
  out:
     close(fd);
     return rv;
+#endif
 }
 
 static void

--- a/ui/ui_os.c
+++ b/ui/ui_os.c
@@ -226,6 +226,9 @@ free_timer(os_handler_t *handler, os_hnd_timer_id_t *timer_data)
 static int
 get_random(os_handler_t *handler, void *data, unsigned int len)
 {
+#ifdef _WIN32
+    #error get_random() to be defined for Windows
+#else
     int fd = open("/dev/urandom", O_RDONLY);
     int rv;
 
@@ -246,6 +249,7 @@ get_random(os_handler_t *handler, void *data, unsigned int len)
  out:
     close(fd);
     return rv;
+#endif
 }
 
 extern void ui_vlog(const char *format, enum ipmi_log_type_e log_type,

--- a/utils/ipmi_malloc.c
+++ b/utils/ipmi_malloc.c
@@ -66,6 +66,7 @@
 #include <OpenIPMI/internal/ipmi_malloc.h>
 #include <OpenIPMI/internal/ilist.h>
 
+IPMI_UTILS_DLL_PUBLIC
 void (*ipmi_malloc_log)(enum ipmi_log_type_e log_type, const char *format, ...)
 #if __GNUC__ > 2
      __attribute__ ((__format__ (__printf__, 2, 3)))


### PR DESCRIPTION
- Fixed the ipmi_malloc_log dllexport/dllimport issue -> now the library builds (both static and shared)
- More fixes related to differences between Unix and Winsock sockets. Winsock requires `closesocket()` instead of `close()`
- I believe there are calls to `read()` on sockets, which won't work with Winsock, these should probably be replaced with `recv()` -> still to be fixed
- I noticed there are randomization functions using `open("/dev/urandom", O_RDONLY)`, this is definitely not portable to Windows -> still to be fixed